### PR TITLE
Handle credit report response returning None

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+ROOTDIR := $(CURDIR)
+
+.PHONY: format
+format:
+	black .
+
+.PHONY: lint
+lint:
+	@for FEATUREDIR in lib/*; do \
+		WORKDIR=$(ROOTDIR)/$$FEATUREDIR ; \
+		echo "\nChecking: $$WORKDIR" ; \
+		cd $$WORKDIR \
+			&& black --check . \
+			&& mypy . ; \
+	done

--- a/lib/net_cash_flow/main.py
+++ b/lib/net_cash_flow/main.py
@@ -4,7 +4,7 @@ import os
 from datetime import datetime, timedelta
 from typing import Optional
 
-import pandas as pd
+import pandas as pd  # type: ignore
 from pngme.api import Client
 
 

--- a/lib/sum_of_credits/main.py
+++ b/lib/sum_of_credits/main.py
@@ -3,7 +3,7 @@
 import os
 from datetime import datetime, timedelta
 
-import pandas as pd
+import pandas as pd  # type: ignore
 from pngme.api import Client
 
 

--- a/lib/sum_of_default_loan_balances/main.py
+++ b/lib/sum_of_default_loan_balances/main.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
-"""
-Sum of default loan balances
-"""
 
 import os
+from typing import Optional
 
 from pngme.api import Client
 
 
-def get_sum_of_default_loan_balances(api_client: Client, user_uuid: str) -> float:
+def get_sum_of_default_loan_balances(
+    api_client: Client, user_uuid: str
+) -> Optional[float]:
     """Return the sum of default tradelines.
 
     Uses the credit report resource to sum the value of default tradelines
@@ -17,8 +17,16 @@ def get_sum_of_default_loan_balances(api_client: Client, user_uuid: str) -> floa
     Args:
         api_client: Pngme API client
         user_uuid: Pngme mobile phone user_uuid
+
+    Returns:
+        Total default loan balances, or None if a credit report cannot be
+        generated for the given user.
     """
     credit_report = api_client.credit_report.get(user_uuid)
+
+    if not credit_report:
+        return None
+
     default_tradelines = credit_report["tradelines"]["default"]
     default_loan_balance = 0
     for tradeline in default_tradelines:
@@ -38,4 +46,4 @@ if __name__ == "__main__":
     sum_of_default_loan_balances = get_sum_of_default_loan_balances(
         api_client=client, user_uuid=USER_UUID
     )
-    print(sum_of_default_loan_balance)
+    print(sum_of_default_loan_balances)

--- a/lib/sum_of_loan_repayments/main.py
+++ b/lib/sum_of_loan_repayments/main.py
@@ -2,13 +2,14 @@
 
 import os
 from datetime import datetime, timedelta
+from typing import Optional
 
 from pngme.api import Client
 
 
 def sum_of_loan_repayments(
     api_client: Client, user_uuid: str, utc_starttime: datetime, utc_endtime: datetime
-) -> float:
+) -> Optional[float]:
     """Return the sum of loan repayments over a period for a given user
 
     Args:
@@ -17,11 +18,14 @@ def sum_of_loan_repayments(
         utc_starttime: the datetime for the left-hand-side of the time-window
         utc_endtime: the datetime for the right-hand-side of the time-window
 
-    Return:
+    Returns:
         Total number of loan repayments over a period
     """
 
     credit_report = api_client.credit_report.get(user_uuid)
+
+    if not credit_report:
+        return None
 
     total_loan_repayment = 0
     for loan_repayment in credit_report["loan_repayments"]:

--- a/lib/sum_of_open_and_late_loan_balances/main.py
+++ b/lib/sum_of_open_and_late_loan_balances/main.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 
 import os
+from typing import Optional
 
 from pngme.api import Client
 
 
-def get_sum_of_open_and_late_loan_balances(client: Client, user_uuid: str) -> float:
+def get_sum_of_open_and_late_loan_balances(
+    client: Client, user_uuid: str
+) -> Optional[float]:
     """Return the sum of open and late-payment loan balances
 
     Uses the credit report resource to sum the value of open and late payment
@@ -14,9 +17,16 @@ def get_sum_of_open_and_late_loan_balances(client: Client, user_uuid: str) -> fl
     Args:
         client: Pngme API client
         user_uuid: Pngme mobile phone user_uuid
+
+    Returns:
+        Total open and late loan balances, or None if a credit report cannot be
+        generated for the given user.
     """
 
     credit_report = client.credit_report.get(user_uuid)
+
+    if not credit_report:
+        return None
 
     # Sum the values of all open and late_payment tradelines.
     tradedlines = [


### PR DESCRIPTION
The `api_client.credit_report.get(user_uuid)` can return `None` if the worker service is unable to generate a credit report for a given user.

These changes ensure this case is gracefully handled for features which require a credit report to be generated successfully.