### PR TITLE
sum-of-credits | refactor w/ async

### DIFF
--- a/lib/sum_of_credits/main.py
+++ b/lib/sum_of_credits/main.py
@@ -73,7 +73,6 @@ if __name__ == "__main__":
     client = AsyncClient(token)
 
     now = datetime(2021, 10, 1)
-    ts = datetime.now()
 
     async def main():
         soc_0_30, soc_31_60, soc_61_90 = await get_sum_of_credits(client, user_uuid, now)


### PR DESCRIPTION
To Reviewers: please feel free to merge is 1 or more approvals and no requests for changes.
--

Benchmark:
51 seconds for the 3 features with current implementation.
5 seconds for the 3 features with refactor.

This PR includes changes to:
1. refactor the sum-of-credits method to use async
2. consolidates the 3 common time-bins into this single method

Discussion points:

Do we want to include both the basic synchronous method example and the async?
Perhaps. But for now, let's simply include the async method. We have an evidenced need of performance improvement, as we will be computing feature-sets across a large number of users. We will wait until the need for the synchronous method is evidenced (e.g. customer feedback that they'd like to see a traditional method).

Consolidation of the three time-bins into this single method. We loose generalization, but gain performance. If the need for having a generalized method becomes evidenced, we will consider generalizing again.

alternatives considered:
We could have alternatively refactored to have the /transactions endpoint return all records since the beginning of time, and do the time-window filtering in-memory. This approach may benefit from caching in the api-client, as the query to fetch the transactions would be the same for a given user_uuid, institution_id, regardless of the time range. Best-case scenario, we could expect 2 cache hits. Initial query for e.g. 0-30 range, then cache hits for 31-60 and 61-90. Notable drawbacks include a. pulling a lot of data across the wire (no constraints at present for the total history a user might have), and b. no guarantee of a cache hit -- for large async jobs and limited cache size, it's possible that the cached response is ejected before a subsequent hit, particularly for caching on long-running queries.

A variant of the above might have been to artificially truncate the start_time of the transactions query, based on a timestamp reasonably distant from the utc_starttime and utc_endtime. This is an opaque solution, and makes brittle assumptions about the timerange that a user might chose.