### PR TITLE
Refactor/optimize for relevant institutions

### DIFF
--- a/lib/sum_of_credits/main.py
+++ b/lib/sum_of_credits/main.py
@@ -29,15 +29,22 @@ async def get_sum_of_credits(api_client: AsyncClient, user_uuid: str, utc_time: 
     """
     institutions = await api_client.institutions.get(user_uuid=user_uuid)
 
+    # subset to only fetch data for institutions known to contain depository-type accounts for the user
+    institutions_w_depository = [inst for inst in institutions if "depository" in inst.account_types]
+
     # Constructs a dataframe that contains transactions from all institutions for the user
     record_list = []
     utc_starttime = utc_time - timedelta(days=90)
     inst_coroutines = [
-        api_client.transactions.get(user_uuid=user_uuid,
-                                    institution_id=institution.institution_id,
-                                    utc_starttime=utc_starttime,
-                                    utc_endtime=utc_time)
-        for institution in institutions]
+        api_client.transactions.get(
+            user_uuid=user_uuid,
+            institution_id=institution.institution_id,
+            utc_starttime=utc_starttime,
+            utc_endtime=utc_time,
+            account_types=["depository"],
+        )
+        for institution in institutions_w_depository
+    ]
     r = await asyncio.gather(*inst_coroutines)
     for inst_lst in r:
         record_list.extend([dict(transaction) for transaction in inst_lst])
@@ -53,10 +60,9 @@ async def get_sum_of_credits(api_client: AsyncClient, user_uuid: str, utc_time: 
     ts_60 = (utc_time - timedelta(days=60)).timestamp()
     ts_90 = (utc_time - timedelta(days=90)).timestamp()
 
-    filter_base = (record_df.impact == "CREDIT") & (record_df.account_type == "depository")
-    filter_0_30 = filter_base & (record_df.ts >= ts_30)
-    filter_31_60 = filter_base & (record_df.ts >= ts_60) & (record_df.ts < ts_30)
-    filter_61_90 = filter_base & (record_df.ts >= ts_90) & (record_df.ts < ts_60)
+    filter_0_30 = (record_df.impact == "CREDIT") & (record_df.ts >= ts_30)
+    filter_31_60 = (record_df.impact == "CREDIT") & (record_df.ts >= ts_60) & (record_df.ts < ts_30)
+    filter_61_90 = (record_df.impact == "CREDIT") & (record_df.ts >= ts_90) & (record_df.ts < ts_60)
 
     amount_0_30 = record_df[filter_0_30].amount.sum()
     amount_31_60 = record_df[filter_31_60].amount.sum()


### PR DESCRIPTION
This performs two optimizations, to the three features sum_of_credits, sum_of_debits and sum_of_balances_latest

1. restricts the /balances and /transactions API query to use the `account_types=[]` parameter to minimize unneeded data being sent across the wire and passes filtering responsibility to the API instead of doing it in-mem
2. subsets for those institutions that are known to contain data of relevant account_type for the given feature, thus minimizing extraneous calls to the /transactions or /balances endpoints for institutions that are known not to contain data of the desired account-type

note:
the performance improvement of 2. above is moot for low-concurrency local testing; async'ing queries to the /balances endpoint for N institutions executes nominally with O(1) when N << async_concurrency_limit

When we start doing async jobs across many users and features, however, minimizing extraneous API calls will help considerably given our severally I/O limited feature generation.

For our test user, Mercy, she has 13 institutions total. Only 5 contain data of account_type depository for Mercy.
As such, we reduce our extraneous async API calls by 7/13; a substantial reduction. 