### PR TITLE
requirements.txt specifies min version of pngme-api pkg

### DIFF
--- a/lib/average_end_of_day_balance/requirements.txt
+++ b/lib/average_end_of_day_balance/requirements.txt
@@ -1,2 +1,2 @@
 pandas
-pngme-api
+pngme-api >= 0.5.0

--- a/lib/count_betting_and_lottery_events/requirements.txt
+++ b/lib/count_betting_and_lottery_events/requirements.txt
@@ -1,2 +1,2 @@
 pandas
-pngme-api
+pngme-api >= 0.5.0

--- a/lib/count_insufficient_funds_events/requirements.txt
+++ b/lib/count_insufficient_funds_events/requirements.txt
@@ -1,2 +1,2 @@
 pandas
-pngme-api
+pngme-api >= 0.5.0

--- a/lib/count_loan_declined_events/requirements.txt
+++ b/lib/count_loan_declined_events/requirements.txt
@@ -1,2 +1,2 @@
 pandas
-pngme-api
+pngme-api >= 0.5.0

--- a/lib/count_loan_defaulted_events/requirements.txt
+++ b/lib/count_loan_defaulted_events/requirements.txt
@@ -1,2 +1,2 @@
 pandas
-pngme-api
+pngme-api >= 0.5.0

--- a/lib/count_loan_repaid_events/requirements.txt
+++ b/lib/count_loan_repaid_events/requirements.txt
@@ -1,2 +1,2 @@
 pandas
-pngme-api
+pngme-api >= 0.5.0

--- a/lib/count_loan_repayment_events/requirements.txt
+++ b/lib/count_loan_repayment_events/requirements.txt
@@ -1,2 +1,2 @@
 pandas
-pngme-api
+pngme-api >= 0.5.0

--- a/lib/count_missed_payment_events/requirements.txt
+++ b/lib/count_missed_payment_events/requirements.txt
@@ -1,2 +1,2 @@
 pandas
-pngme-api
+pngme-api >= 0.5.0

--- a/lib/count_opened_loans/requirements.txt
+++ b/lib/count_opened_loans/requirements.txt
@@ -1,2 +1,2 @@
 pandas
-pngme-api
+pngme-api >= 0.5.0

--- a/lib/count_overdraft_events/requirements.txt
+++ b/lib/count_overdraft_events/requirements.txt
@@ -1,2 +1,2 @@
 pandas
-pngme-api
+pngme-api >= 0.5.0

--- a/lib/debt_to_income_ratio_latest/requirements.txt
+++ b/lib/debt_to_income_ratio_latest/requirements.txt
@@ -1,2 +1,2 @@
 pandas
-pngme-api
+pngme-api >= 0.5.0

--- a/lib/net_cash_flow/requirements.txt
+++ b/lib/net_cash_flow/requirements.txt
@@ -1,2 +1,2 @@
 pandas
-pngme-api
+pngme-api >= 0.5.0

--- a/lib/standard_deviation_of_week_to_week_sum_of_credits/requirements.txt
+++ b/lib/standard_deviation_of_week_to_week_sum_of_credits/requirements.txt
@@ -1,2 +1,2 @@
 pandas
-pngme-api
+pngme-api >= 0.5.0

--- a/lib/sum_of_balances_latest/requirements.txt
+++ b/lib/sum_of_balances_latest/requirements.txt
@@ -1,2 +1,2 @@
 pandas
-pngme-api
+pngme-api >= 0.5.0

--- a/lib/sum_of_credits/requirements.txt
+++ b/lib/sum_of_credits/requirements.txt
@@ -1,2 +1,2 @@
 pandas
-pngme-api
+pngme-api >= 0.5.0

--- a/lib/sum_of_debits/requirements.txt
+++ b/lib/sum_of_debits/requirements.txt
@@ -1,2 +1,2 @@
 pandas
-pngme-api
+pngme-api >= 0.5.0

--- a/lib/sum_of_default_loan_balances/requirements.txt
+++ b/lib/sum_of_default_loan_balances/requirements.txt
@@ -1,1 +1,1 @@
-pngme-api
+pngme-api >= 0.5.0

--- a/lib/sum_of_loan_repayments/requirements.txt
+++ b/lib/sum_of_loan_repayments/requirements.txt
@@ -1,1 +1,1 @@
-pngme-api
+pngme-api >= 0.5.0

--- a/lib/sum_of_minimum_balances/requirements.txt
+++ b/lib/sum_of_minimum_balances/requirements.txt
@@ -1,1 +1,1 @@
-pngme-api
+pngme-api >= 0.5.0

--- a/lib/sum_of_open_and_late_loan_balances/requirements.txt
+++ b/lib/sum_of_open_and_late_loan_balances/requirements.txt
@@ -1,1 +1,1 @@
-pngme-api
+pngme-api >= 0.5.0


### PR DESCRIPTION
- `requirements.txt` now specifies minimum version of `pngme-api` package to be installed

- Tested locally to verify expected behavior 