### PR TITLE
PDP-1134: pandas dependency removed from count_loan_defaulted_events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ dmypy.json
 
 # IDE settings
 .idea
+
+# VS Code settings
+.vscode

--- a/lib/count_loan_defaulted_events/main.py
+++ b/lib/count_loan_defaulted_events/main.py
@@ -3,9 +3,7 @@ import asyncio
 import os
 from datetime import datetime, timedelta
 
-import pandas as pd  # type: ignore
 from typing import Tuple
-
 from pngme.api import AsyncClient
 
 
@@ -24,8 +22,6 @@ async def get_count_loan_defaulted_events(
     Returns:
         count of LoanDefaulted events within the given time window
     """
-    label = "LoanDefaulted"
-
     institutions = await api_client.institutions.get(user_uuid=user_uuid)
 
     # subset to only fetch data for institutions known to contain loan-type accounts for the user
@@ -33,42 +29,46 @@ async def get_count_loan_defaulted_events(
         inst for inst in institutions if "loan" in inst.account_types
     ]
 
+    # at most, we retrieve data from last 90 days
     utc_starttime = utc_time - timedelta(days=90)
+    
+    # API call including the label filter so only "LoanDefaulted" events are returned if they exist
     inst_coroutines = [
         api_client.alerts.get(
             user_uuid=user_uuid,
             institution_id=institution.institution_id,
             utc_starttime=utc_starttime,
             utc_endtime=utc_time,
-            labels=[label],
+            labels=["LoanDefaulted"],
         )
         for institution in institutions_w_loan
     ]
 
     r = await asyncio.gather(*inst_coroutines)
 
+    # now we aggregate the results from each institution into a single list
     record_list = []
     for inst_list in r:
         record_list.extend([dict(alert) for alert in inst_list])
 
-    # if no data available for the user, assume count of LoanDefaulted event is zero
-    if len(record_list) == 0:
-        return 0, 0, 0
-
-    record_df = pd.DataFrame(record_list)
-
+    # now we prepare the time windows for the counts
     ts_30 = (utc_time - timedelta(days=30)).timestamp()
     ts_60 = (utc_time - timedelta(days=60)).timestamp()
     ts_90 = (utc_time - timedelta(days=90)).timestamp()
 
-    filter_0_30 = record_df.ts >= ts_30
-    filter_31_60 = (record_df.ts >= ts_60) & (record_df.ts < ts_30)
-    filter_61_90 = (record_df.ts >= ts_90) & (record_df.ts < ts_60)
+    # now we count the number of events in each time window
+    count_loan_defaulted_events_0_30 = 0
+    count_loan_defaulted_events_31_60 = 0
+    count_loan_defaulted_events_61_90 = 0
 
-    count_loan_defaulted_events_0_30 = len(record_df[filter_0_30])
-    count_loan_defaulted_events_31_60 = len(record_df[filter_31_60])
-    count_loan_defaulted_events_61_90 = len(record_df[filter_61_90])
-
+    for r in record_list:
+        if r["ts"] >= ts_30:
+            count_loan_defaulted_events_0_30 += 1
+        if r["ts"] >= ts_60 and r["ts"] < ts_30:
+            count_loan_defaulted_events_31_60 += 1
+        if r["ts"] >= ts_90 and r["ts"] < ts_60:
+            count_loan_defaulted_events_61_90 += 1
+    
     return (
         count_loan_defaulted_events_0_30,
         count_loan_defaulted_events_31_60,
@@ -78,6 +78,7 @@ async def get_count_loan_defaulted_events(
 
 if __name__ == "__main__":
     # Mercy Otieno, mercy@pngme.demo.com, 254123456789
+    # Has a LoanDefaulted with toc = 1633712575 (Fri Oct 08 2021 17:02:55 GMT+0000)
     user_uuid = "958a5ae8-f3a3-41d5-ae48-177fdc19e3f4"
 
     token = os.environ["PNGME_TOKEN"]
@@ -91,6 +92,7 @@ if __name__ == "__main__":
             count_loan_defaulted_events_31_60,
             count_loan_defaulted_events_61_90,
         ) = await get_count_loan_defaulted_events(client, user_uuid, now)
+        
         print(count_loan_defaulted_events_0_30)
         print(count_loan_defaulted_events_31_60)
         print(count_loan_defaulted_events_61_90)

--- a/lib/count_loan_defaulted_events/requirements.txt
+++ b/lib/count_loan_defaulted_events/requirements.txt
@@ -1,2 +1,1 @@
-pandas
 pngme-api >= 0.5.0

--- a/lib/net_cash_flow/main.py
+++ b/lib/net_cash_flow/main.py
@@ -4,7 +4,6 @@ import os
 from datetime import datetime, timedelta
 from typing import Optional
 
-import pandas as pd  # type: ignore
 from pngme.api import Client
 
 
@@ -51,15 +50,14 @@ def get_net_cash_flow(
     if len(record_list) == 0:
         return None
 
-    transaction_df = pd.DataFrame(record_list)
-
     # Get the total cash-in (credit) amount over a period
-    cash_in_amount = transaction_df[(transaction_df.impact == "CREDIT")].amount.sum()
+    cash_in_amount = sum([r["amount"] for r in record_list if r["impact"] == "CREDIT"])
 
     # Get the total cash-out (debit) amount over a period
-    cash_out_amount = transaction_df[(transaction_df.impact == "DEBIT")].amount.sum()
+    cash_out_amount = sum([r["amount"] for r in record_list if r["impact"] == "DEBIT"])
 
     total_net_cash_flow = cash_in_amount - cash_out_amount
+
     return total_net_cash_flow
 
 

--- a/lib/net_cash_flow/main.py
+++ b/lib/net_cash_flow/main.py
@@ -51,11 +51,18 @@ def get_net_cash_flow(
         return None
 
     # Get the total cash-in (credit) amount over a period
-    cash_in_amount = sum([r["amount"] for r in record_list if r["impact"] == "CREDIT"])
+    cash_in_amount = 0
+    for r in record_list:
+        if r["impact"] == "CREDIT":
+            cash_in_amount += r["amount"]
 
     # Get the total cash-out (debit) amount over a period
-    cash_out_amount = sum([r["amount"] for r in record_list if r["impact"] == "DEBIT"])
+    cash_out_amount = 0
+    for r in record_list:
+        if r["impact"] == "DEBIT":
+            cash_out_amount += r["amount"]
 
+    # Compute the net cash flow as the difference between cash-in and cash-out
     total_net_cash_flow = cash_in_amount - cash_out_amount
 
     return total_net_cash_flow

--- a/lib/net_cash_flow/requirements.txt
+++ b/lib/net_cash_flow/requirements.txt
@@ -1,2 +1,1 @@
-pandas
 pngme-api >= 0.5.0

--- a/lib/sum_of_credits/requirements.txt
+++ b/lib/sum_of_credits/requirements.txt
@@ -1,2 +1,1 @@
-pandas
 pngme-api >= 0.5.0

--- a/lib/sum_of_debits/main.py
+++ b/lib/sum_of_debits/main.py
@@ -3,7 +3,6 @@
 import asyncio
 import os
 from datetime import datetime, timedelta
-import pandas as pd  # type: ignore
 from typing import Tuple
 
 from pngme.api import AsyncClient
@@ -27,15 +26,17 @@ async def get_sum_of_debits(
 
     Returns:
         the sum total of all debit transaction amounts over the predefined ranges.
+            If there are no debit transactions for a given period, returns None
     """
     institutions = await api_client.institutions.get(user_uuid=user_uuid)
 
     # subset to only fetch data for institutions known to contain depository-type accounts for the user
     institutions_w_depository = [inst for inst in institutions if "depository" in inst.account_types]
 
-    # Constructs a dataframe that contains transactions from all institutions for the user
-    record_list = []
+    # at most, we retrieve data from last 90 days
     utc_starttime = utc_time - timedelta(days=90)
+    
+    # API call including the account type filter so only "depository" transactions are returned if they exist
     inst_coroutines = [
         api_client.transactions.get(
             user_uuid=user_uuid,
@@ -47,30 +48,38 @@ async def get_sum_of_debits(
         for institution in institutions_w_depository
     ]
     r = await asyncio.gather(*inst_coroutines)
+
+    # now we aggregate the results from each institution into a single list
+    record_list = []
     for inst_list in r:
         record_list.extend([dict(transaction) for transaction in inst_list])
-
-    # if no data available for the user, assume cash-out is zero
-    if len(record_list) == 0:
-        return 0.0, 0.0, 0.0
-
-    record_df = pd.DataFrame(record_list)
 
     # Get the total outbound debit over a period
     ts_30 = (utc_time - timedelta(days=30)).timestamp()
     ts_60 = (utc_time - timedelta(days=60)).timestamp()
     ts_90 = (utc_time - timedelta(days=90)).timestamp()
 
-    filter_0_30 = (record_df.impact == "DEBIT") & (record_df.ts >= ts_30)
-    filter_31_60 = (record_df.impact == "DEBIT") & (record_df.ts >= ts_60) & (record_df.ts < ts_30)
-    filter_61_90 = (record_df.impact == "DEBIT") & (record_df.ts >= ts_90) & (record_df.ts < ts_60)
+    # now we sum the transaction amounts in each time window
+    amount_0_30 = None
+    amount_31_60 = None
+    amount_61_90 = None
 
-    amount_0_30 = record_df[filter_0_30].amount.sum()
-    amount_31_60 = record_df[filter_31_60].amount.sum()
-    amount_61_90 = record_df[filter_61_90].amount.sum()
+    for r in record_list:
+        if r["impact"] == "DEBIT":
+            if r["ts"] >= ts_30:
+                amount_0_30 = _update_total(r["amount"], amount_0_30)
+            elif r["ts"] >= ts_60:
+                amount_31_60 = _update_total(r["amount"], amount_31_60)
+            elif r["ts"] >= ts_90:
+                amount_61_90 = _update_total(r["amount"], amount_61_90)
 
     return amount_0_30, amount_31_60, amount_61_90
 
+def _update_total(amount, total):
+    if total is None:
+        total = 0
+    total += amount
+    return total
 
 if __name__ == "__main__":
     # Mercy Otieno, mercy@pngme.demo.com, 254123456789

--- a/lib/sum_of_debits/requirements.txt
+++ b/lib/sum_of_debits/requirements.txt
@@ -1,2 +1,1 @@
-pandas
 pngme-api >= 0.5.0


### PR DESCRIPTION
Removes the use of pandas from the following features:
* count of defaulted loans
* sum of credits
* sum of debits
* net cash flow

Features that could not have data for a given period now return `None` instead of defaulting to zero for such period.