### PR TITLE
PDP-1140: depandification of counts

### DIFF
--- a/lib/count_betting_and_lottery_events/main.py
+++ b/lib/count_betting_and_lottery_events/main.py
@@ -4,10 +4,7 @@ import os
 from datetime import datetime, timedelta
 from re import I
 
-import pandas as pd  # type: ignore
-
 from pngme.api import AsyncClient
-
 
 async def get_count_betting_and_lottery_events(
     api_client: AsyncClient,
@@ -48,13 +45,10 @@ async def get_count_betting_and_lottery_events(
     if len(record_list) == 0:
         return 0
 
-    record_df = pd.DataFrame(record_list)
-
-    time_window_filter = (record_df.ts >= utc_starttime.timestamp()) & (
-        record_df.ts < utc_endtime.timestamp()
-    )
-
-    count_betting_and_lottery_events = len(record_df[time_window_filter])
+    count_betting_and_lottery_events = 0
+    for alert in record_list:
+        if alert["ts"] >= utc_starttime.timestamp() and alert["ts"] < utc_endtime.timestamp():
+            count_betting_and_lottery_events += 1
 
     return count_betting_and_lottery_events
 

--- a/lib/count_betting_and_lottery_events/requirements.txt
+++ b/lib/count_betting_and_lottery_events/requirements.txt
@@ -1,2 +1,1 @@
-pandas
 pngme-api >= 0.5.0

--- a/lib/count_insufficient_funds_events/main.py
+++ b/lib/count_insufficient_funds_events/main.py
@@ -3,8 +3,6 @@ import asyncio
 import os
 from datetime import datetime, timedelta
 
-import pandas as pd  # type: ignore
-
 from pngme.api import AsyncClient
 
 
@@ -53,13 +51,10 @@ async def get_count_insufficient_funds_events(
     if len(record_list) == 0:
         return 0
 
-    record_df = pd.DataFrame(record_list)
-
-    time_window_filter = (record_df.ts >= utc_starttime.timestamp()) & (
-        record_df.ts < utc_endtime.timestamp()
-    )
-
-    count_insufficient_funds_events = len(record_df[time_window_filter])
+    count_insufficient_funds_events = 0
+    for alert in record_list:
+        if alert["ts"] >= utc_starttime.timestamp() and alert["ts"] < utc_endtime.timestamp():
+            count_insufficient_funds_events += 1
 
     return count_insufficient_funds_events
 

--- a/lib/count_insufficient_funds_events/requirements.txt
+++ b/lib/count_insufficient_funds_events/requirements.txt
@@ -1,2 +1,1 @@
-pandas
 pngme-api >= 0.5.0

--- a/lib/count_loan_declined_events/main.py
+++ b/lib/count_loan_declined_events/main.py
@@ -3,8 +3,6 @@ import asyncio
 import os
 from datetime import datetime, timedelta
 
-import pandas as pd  # type: ignore
-
 from pngme.api import AsyncClient
 
 
@@ -49,17 +47,11 @@ async def get_count_loan_declined_events(
     for inst_list in r:
         record_list.extend([dict(alert) for alert in inst_list])
 
-    # if no data available for the user, assume count of LoanDeclined event is zero
-    if len(record_list) == 0:
-        return 0
 
-    record_df = pd.DataFrame(record_list)
-
-    time_window_filter = (record_df.ts >= utc_starttime.timestamp()) & (
-        record_df.ts < utc_endtime.timestamp()
-    )
-
-    count_loan_declined_events = len(record_df[time_window_filter])
+    count_loan_declined_events = 0
+    for alert in record_list:
+        if alert["ts"] >= utc_starttime.timestamp() and alert["ts"] < utc_endtime.timestamp():
+            count_loan_declined_events += 1
 
     return count_loan_declined_events
 

--- a/lib/count_loan_declined_events/requirements.txt
+++ b/lib/count_loan_declined_events/requirements.txt
@@ -1,2 +1,1 @@
-pandas
 pngme-api >= 0.5.0

--- a/lib/count_loan_repaid_events/main.py
+++ b/lib/count_loan_repaid_events/main.py
@@ -3,8 +3,6 @@ import asyncio
 import os
 from datetime import datetime, timedelta
 
-import pandas as pd  # type: ignore
-
 from pngme.api import AsyncClient
 
 
@@ -45,16 +43,10 @@ async def get_count_loan_repaid_events(
     for inst_list in r:
         record_list.extend([dict(alert) for alert in inst_list])
 
-    # if no data available for the user, assume count of LoanRepaid event is zero
-    if len(record_list) == 0:
-        return 0
-
-    record_df = pd.DataFrame(record_list)
-
-    time_window_filter = (record_df.ts >= utc_starttime.timestamp()) & (
-        record_df.ts < utc_endtime.timestamp()
-    )
-    count_loan_repaid_events = len(record_df[time_window_filter])
+    count_loan_repaid_events = 0
+    for alert in record_list:
+        if alert["ts"] >= utc_starttime.timestamp() and alert["ts"] < utc_endtime.timestamp():
+            count_loan_repaid_events += 1
 
     return count_loan_repaid_events
 

--- a/lib/count_loan_repaid_events/requirements.txt
+++ b/lib/count_loan_repaid_events/requirements.txt
@@ -1,2 +1,1 @@
-pandas
 pngme-api >= 0.5.0

--- a/lib/count_loan_repayment_events/main.py
+++ b/lib/count_loan_repayment_events/main.py
@@ -3,8 +3,6 @@ import asyncio
 import os
 from datetime import datetime, timedelta
 
-import pandas as pd  # type: ignore
-
 from pngme.api import AsyncClient
 
 
@@ -45,16 +43,10 @@ async def get_count_loan_repayment_events(
     for inst_list in r:
         record_list.extend([dict(alert) for alert in inst_list])
 
-    # if no data available for the user, assume count of LoanRepaid event is zero
-    if len(record_list) == 0:
-        return 0
-
-    record_df = pd.DataFrame(record_list)
-
-    time_window_filter = (record_df.ts >= utc_starttime.timestamp()) & (
-        record_df.ts < utc_endtime.timestamp()
-    )
-    count_loan_repayment_events = len(record_df[time_window_filter])
+    count_loan_repayment_events = 0
+    for alert in record_list:
+        if alert["ts"] >= utc_starttime.timestamp() and alert["ts"] < utc_endtime.timestamp():
+            count_loan_repayment_events += 1
 
     return count_loan_repayment_events
 

--- a/lib/count_loan_repayment_events/requirements.txt
+++ b/lib/count_loan_repayment_events/requirements.txt
@@ -1,2 +1,1 @@
-pandas
 pngme-api >= 0.5.0

--- a/lib/count_missed_payment_events/main.py
+++ b/lib/count_missed_payment_events/main.py
@@ -3,8 +3,6 @@ import asyncio
 import os
 from datetime import datetime, timedelta
 
-import pandas as pd  # type: ignore
-
 from pngme.api import AsyncClient
 
 
@@ -45,18 +43,12 @@ async def get_count_missed_payment_events(
     for inst_list in r:
         record_list.extend([dict(alert) for alert in inst_list])
 
-    # if no data available for the user, assume count of LoanRepaid event is zero
-    if len(record_list) == 0:
-        return 0
+    count_loan_missed_payments_events = 0
+    for alert in record_list:
+        if alert["ts"] >= utc_starttime.timestamp() and alert["ts"] < utc_endtime.timestamp():
+            count_loan_missed_payments_events += 1
 
-    record_df = pd.DataFrame(record_list)
-
-    time_window_filter = (record_df.ts >= utc_starttime.timestamp()) & (
-        record_df.ts < utc_endtime.timestamp()
-    )
-    count_loan_missedpayments_events = len(record_df[time_window_filter])
-
-    return count_loan_missedpayments_events
+    return count_loan_missed_payments_events
 
 
 if __name__ == "__main__":

--- a/lib/count_missed_payment_events/requirements.txt
+++ b/lib/count_missed_payment_events/requirements.txt
@@ -1,2 +1,1 @@
-pandas
 pngme-api >= 0.5.0

--- a/lib/count_overdraft_events/main.py
+++ b/lib/count_overdraft_events/main.py
@@ -3,8 +3,6 @@ import asyncio
 import os
 from datetime import datetime, timedelta
 
-import pandas as pd  # type: ignore
-
 from pngme.api import AsyncClient
 
 
@@ -45,17 +43,12 @@ async def get_count_overdraft_events(
     for inst_list in r:
         record_list.extend([dict(alert) for alert in inst_list])
 
-    # if no data available for the user, assume count of LoanRepaid event is zero
-    if len(record_list) == 0:
-        return 0
-
-    record_df = pd.DataFrame(record_list)
-
-    time_window_filter = (record_df.ts >= utc_starttime.timestamp()) & (
-        record_df.ts < utc_endtime.timestamp()
-    )
-
-    return len(record_df[time_window_filter])
+    count_overdraft_events = 0
+    for alert in record_list:
+        if alert["ts"] >= utc_starttime.timestamp() and alert["ts"] < utc_endtime.timestamp():
+            count_overdraft_events += 1
+    
+    return count_overdraft_events
 
 
 if __name__ == "__main__":

--- a/lib/count_overdraft_events/requirements.txt
+++ b/lib/count_overdraft_events/requirements.txt
@@ -1,2 +1,1 @@
-pandas
 pngme-api >= 0.5.0


### PR DESCRIPTION
Most changes here are always the same: replace the pandas counting with a simple loop + if to count alerts within the time window.

The only one that is not clear for me is `count_opened_loans`. The original code was not clear to me and I just simplified it accordingly to what I would expect from this feature by reading the doctoring (and also given the context of all the other counting features)

I need @AdityaRao1996 to help me reviewing this in case I am missing something