### PR TITLE
[PDP-1278] Timestamps are sure to be of UTC timezone

### DIFF
--- a/lib/average_end_of_day_loan_balance/main.py
+++ b/lib/average_end_of_day_loan_balance/main.py
@@ -2,7 +2,7 @@
 import asyncio
 import os
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone, tzinfo
 from typing import Optional
 
 import pandas as pd  # type: ignore
@@ -30,6 +30,10 @@ async def get_average_end_of_day_balance(
     Returns:
         the average end-of-day total balance over each window
     """
+    # Make sure the timestamps are of UTC timezone
+    utc_starttime = utc_starttime.astimezone(timezone.utc)
+    utc_endtime = utc_endtime.astimezone(timezone.utc)
+
     # STEP 1: fetch list of institutions belonging to the user
     institutions = await api_client.institutions.get(user_uuid=user_uuid)
 
@@ -69,8 +73,8 @@ async def get_average_end_of_day_balance(
             balance_dict["institution_id"] = institution_id
 
             record_list.append(balance_dict)
-            
-    # if no data is present, consider the sum of balances to be non-existing 
+
+    # if no data is present, consider the sum of balances to be non-existing
     if len(record_list) == 0:
         return None
 
@@ -78,10 +82,9 @@ async def get_average_end_of_day_balance(
     balances_df = pd.DataFrame(record_list)
 
     # Sort and create a column for day, filter by time window
-    balances_df["timestamp"] = balances_df["timestamp"].astype('datetime64[D]')
+    balances_df["timestamp"] = pd.to_datetime(balances_df["timestamp"])
     balances_df = balances_df.sort_values("timestamp")
-    balances_df["yyyymmdd"] = pd.to_datetime(balances_df["timestamp"])
-    balances_df["yyyymmdd"] = balances_df["yyyymmdd"].dt.floor("D")
+    balances_df["yyyymmdd"] = balances_df["timestamp"].dt.floor("D")
 
     # Get end of day balances,
     # If an account changes balances three times a day in sequence, i.e. $100, $20, $120),

--- a/lib/count_betting_and_lottery_events/main.py
+++ b/lib/count_betting_and_lottery_events/main.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 import asyncio
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from pngme.api import AsyncClient
+
 
 async def get_count_betting_and_lottery_events(
     api_client: AsyncClient,
@@ -22,9 +23,13 @@ async def get_count_betting_and_lottery_events(
     Returns:
         count of BettingAndLottery events within the given time window
     """
+    # Make sure the timestamps are of UTC timezone
+    utc_starttime = utc_starttime.astimezone(timezone.utc).replace(tzinfo=None)
+    utc_endtime = utc_endtime.astimezone(timezone.utc).replace(tzinfo=None)
+
     # STEP 1: fetch list of institutions belonging to the user
     institutions = await api_client.institutions.get(user_uuid=user_uuid)
-    
+
     # subset to only fetch data for institutions known to contain depository-type accounts for the user
     institutions_w_depository = []
     for inst in institutions:

--- a/lib/count_insufficient_funds_events/main.py
+++ b/lib/count_insufficient_funds_events/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import asyncio
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from pngme.api import AsyncClient
 
@@ -23,6 +23,10 @@ async def get_count_insufficient_funds_events(
     Returns:
         count of InsufficientFunds events within the given time window
     """
+    # Make sure the timestamps are of UTC timezone
+    utc_starttime = utc_starttime.astimezone(timezone.utc).replace(tzinfo=None)
+    utc_endtime = utc_endtime.astimezone(timezone.utc).replace(tzinfo=None)
+
     # STEP 1: fetch list of institutions belonging to the user
     institutions = await api_client.institutions.get(user_uuid=user_uuid)
 
@@ -75,5 +79,5 @@ if __name__ == "__main__":
             utc_endtime,
         )
         print(count_insufficient_funds_events)
-    
+
     asyncio.run(main())

--- a/lib/count_loan_declined_events/main.py
+++ b/lib/count_loan_declined_events/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import asyncio
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from pngme.api import AsyncClient
 
@@ -23,6 +23,10 @@ async def get_count_loan_declined_events(
     Returns:
         count of LoanDeclined events within the given time window
     """
+    # Make sure the timestamps are of UTC timezone
+    utc_starttime = utc_starttime.astimezone(timezone.utc).replace(tzinfo=None)
+    utc_endtime = utc_endtime.astimezone(timezone.utc).replace(tzinfo=None)
+
     # STEP 1: fetch list of institutions belonging to the user
     institutions = await api_client.institutions.get(user_uuid=user_uuid)
 

--- a/lib/count_loan_defaulted_events/main.py
+++ b/lib/count_loan_defaulted_events/main.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 import asyncio
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
-from typing import Tuple
 from pngme.api import AsyncClient
 
 
@@ -26,6 +25,9 @@ async def get_count_loan_defaulted_events(
     Returns:
         count of LoanDefaulted events within the given time window
     """
+    # Make sure the timestamps are of UTC timezone
+    utc_starttime = utc_starttime.astimezone(timezone.utc).replace(tzinfo=None)
+    utc_endtime = utc_endtime.astimezone(timezone.utc).replace(tzinfo=None)
 
     # STEP 1: fetch a list of the user's institutions with loan-type data
     institutions = await api_client.institutions.get(user_uuid=user_uuid)

--- a/lib/count_loan_repaid_events/main.py
+++ b/lib/count_loan_repaid_events/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import asyncio
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from pngme.api import AsyncClient
 
@@ -24,6 +24,10 @@ async def get_count_loan_repaid_events(
     Returns:
         count of LoanRepaid events within the given time window
     """
+    # Make sure the timestamps are of UTC timezone
+    utc_starttime = utc_starttime.astimezone(timezone.utc).replace(tzinfo=None)
+    utc_endtime = utc_endtime.astimezone(timezone.utc).replace(tzinfo=None)
+
     # STEP 1: fetch list of institutions belonging to the user
     institutions = await api_client.institutions.get(user_uuid=user_uuid)
 
@@ -50,7 +54,6 @@ async def get_count_loan_repaid_events(
 
     # STEP 4: count number of alerts
     return len(all_alerts)
-
 
 
 if __name__ == "__main__":

--- a/lib/count_loan_repayment_events/main.py
+++ b/lib/count_loan_repayment_events/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import asyncio
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from pngme.api import AsyncClient
 
@@ -24,6 +24,10 @@ async def get_count_loan_repayment_events(
     Returns:
         count of LoanRepayment events within the given time window
     """
+    # Make sure the timestamps are of UTC timezone
+    utc_starttime = utc_starttime.astimezone(timezone.utc).replace(tzinfo=None)
+    utc_endtime = utc_endtime.astimezone(timezone.utc).replace(tzinfo=None)
+
     # STEP 1: fetch list of institutions belonging to the user
     institutions = await api_client.institutions.get(user_uuid=user_uuid)
 
@@ -50,7 +54,6 @@ async def get_count_loan_repayment_events(
 
     # STEP 4: count number of alerts
     return len(all_alerts)
-
 
 
 if __name__ == "__main__":

--- a/lib/count_missed_payment_events/main.py
+++ b/lib/count_missed_payment_events/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import asyncio
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from pngme.api import AsyncClient
 
@@ -24,6 +24,10 @@ async def get_count_missed_payment_events(
     Returns:
         count of LoanMissedPayment events within the given time window
     """
+    # Make sure the timestamps are of UTC timezone
+    utc_starttime = utc_starttime.astimezone(timezone.utc).replace(tzinfo=None)
+    utc_endtime = utc_endtime.astimezone(timezone.utc).replace(tzinfo=None)
+
     # STEP 1: fetch list of institutions belonging to the user
     institutions = await api_client.institutions.get(user_uuid=user_uuid)
 

--- a/lib/count_opened_loans/main.py
+++ b/lib/count_opened_loans/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import asyncio
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from pngme.api import AsyncClient
 
@@ -28,6 +28,10 @@ async def get_count_institutions_with_open_loans(
     Returns:
         count of institutions with one or more opened loans
     """
+    # Make sure the timestamps are of UTC timezone
+    utc_starttime = utc_starttime.astimezone(timezone.utc).replace(tzinfo=None)
+    utc_endtime = utc_endtime.astimezone(timezone.utc).replace(tzinfo=None)
+
     # STEP 1: fetch list of institutions belonging to the user
     institutions = await api_client.institutions.get(user_uuid=user_uuid)
 
@@ -72,13 +76,11 @@ if __name__ == "__main__":
     utc_starttime = utc_endtime - timedelta(days=30)
 
     async def main():
-        count_opened_loans = (
-            await get_count_institutions_with_open_loans(
-                client,
-                user_uuid,
-                utc_starttime,
-                utc_endtime,
-            )
+        count_opened_loans = await get_count_institutions_with_open_loans(
+            client,
+            user_uuid,
+            utc_starttime,
+            utc_endtime,
         )
 
         print(count_opened_loans)

--- a/lib/count_overdraft_events/main.py
+++ b/lib/count_overdraft_events/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import asyncio
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from pngme.api import AsyncClient
 
@@ -24,6 +24,10 @@ async def get_count_overdraft_events(
     Returns:
         count of Overdraft events within the given time window
     """
+    # Make sure the timestamps are of UTC timezone
+    utc_starttime = utc_starttime.astimezone(timezone.utc).replace(tzinfo=None)
+    utc_endtime = utc_endtime.astimezone(timezone.utc).replace(tzinfo=None)
+
     # STEP 1: fetch list of institutions belonging to the user
     institutions = await api_client.institutions.get(user_uuid=user_uuid)
 

--- a/lib/data_recency_minutes/main.py
+++ b/lib/data_recency_minutes/main.py
@@ -25,6 +25,9 @@ async def get_data_recency_minutes(
     Returns:
         Return the time in minutes between utc_endtime and the most recent financial event or alert
     """
+    # Make sure the timestamps are of UTC timezone
+    utc_starttime = utc_starttime.astimezone(timezone.utc).replace(tzinfo=None)
+    utc_endtime = utc_endtime.astimezone(timezone.utc).replace(tzinfo=None)
 
     # STEP 1: fetch list of institutions belonging to the user
     institutions = await api_client.institutions.get(user_uuid=user_uuid)

--- a/lib/net_cash_flow/main.py
+++ b/lib/net_cash_flow/main.py
@@ -2,13 +2,16 @@
 
 import asyncio
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from pngme.api import AsyncClient
 
 
 async def get_net_cash_flow(
-    api_client: AsyncClient, user_uuid: str, utc_starttime: datetime, utc_endtime: datetime
+    api_client: AsyncClient,
+    user_uuid: str,
+    utc_starttime: datetime,
+    utc_endtime: datetime,
 ) -> float:
     """Compute the net cash flow for a user over a given period.
 
@@ -24,6 +27,10 @@ async def get_net_cash_flow(
     Returns:
         the net cash flow amount (differencing cash-in (credit) and cash-out (debit) transactions)
     """
+    # Make sure the timestamps are of UTC timezone
+    utc_starttime = utc_starttime.astimezone(timezone.utc).replace(tzinfo=None)
+    utc_endtime = utc_endtime.astimezone(timezone.utc).replace(tzinfo=None)
+
     # STEP 1: fetch list of institutions belonging to the user
     institutions = await api_client.institutions.get(user_uuid=user_uuid)
 
@@ -36,14 +43,15 @@ async def get_net_cash_flow(
     # STEP 2: Loop through all transactions adding the transactions
     inst_coroutines = []
     for institution in institutions_w_depository:
-        inst_coroutines.append(api_client.transactions.get(
-            user_uuid=user_uuid,
-            institution_id=institution["institution_id"],
-            utc_starttime=utc_starttime,
-            utc_endtime=utc_endtime,
-            account_types=["depository"],
+        inst_coroutines.append(
+            api_client.transactions.get(
+                user_uuid=user_uuid,
+                institution_id=institution["institution_id"],
+                utc_starttime=utc_starttime,
+                utc_endtime=utc_endtime,
+                account_types=["depository"],
+            )
         )
-    )
     transactions_by_institution = await asyncio.gather(*inst_coroutines)
 
     # STEP 3: Compute the net cash flow as the difference between cash-in and cash-out
@@ -55,7 +63,6 @@ async def get_net_cash_flow(
                 cash_in_amount += transaction["amount"]
             elif transaction["impact"] == "DEBIT":
                 cash_out_amount += transaction["amount"]
-
 
     total_net_cash_flow = cash_in_amount - cash_out_amount
 
@@ -81,5 +88,5 @@ if __name__ == "__main__":
         )
 
         print(net_cash_flow)
-    
+
     asyncio.run(main())

--- a/lib/sum_of_credits/main.py
+++ b/lib/sum_of_credits/main.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from pngme.api import AsyncClient
@@ -32,6 +32,9 @@ async def get_sum_of_credits(
         the sum total of all credit transaction amounts over the time window
             If there are no credit transactions for a given period, returns zero
     """
+    # Make sure the timestamps are of UTC timezone
+    utc_time = utc_time.astimezone(timezone.utc).replace(tzinfo=None)
+
     # STEP 1: get a list of all institutions for the user
     institutions = await api_client.institutions.get(user_uuid=user_uuid)
 
@@ -46,13 +49,13 @@ async def get_sum_of_credits(
     for inst in institutions_w_depository:
         inst_coroutines.append(
             api_client.transactions.get(
-            user_uuid=user_uuid,
-            institution_id=inst["institution_id"],
-            utc_starttime=utc_starttime,
-            utc_endtime=utc_time,
-            account_types=["depository"],
+                user_uuid=user_uuid,
+                institution_id=inst["institution_id"],
+                utc_starttime=utc_starttime,
+                utc_endtime=utc_time,
+                account_types=["depository"],
+            )
         )
-    )
 
     transactions_by_institution = await asyncio.gather(*inst_coroutines)
 
@@ -64,6 +67,7 @@ async def get_sum_of_credits(
                 amount += transaction["amount"]
 
     return amount
+
 
 if __name__ == "__main__":
     # Mercy Otieno, mercy@pngme.demo.com, 254123456789

--- a/lib/sum_of_depository_balances_latest/main.py
+++ b/lib/sum_of_depository_balances_latest/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import asyncio
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from pngme.api import AsyncClient
 
@@ -26,6 +26,9 @@ async def get_sum_of_depository_balances_latest(
     Returns:
         The latest balance summed across all depository accounts
     """
+    # Make sure the timestamps are of UTC timezone
+    utc_starttime = utc_starttime.astimezone(timezone.utc).replace(tzinfo=None)
+    utc_endtime = utc_endtime.astimezone(timezone.utc).replace(tzinfo=None)
 
     # STEP 1: get a list of all institutions for the user
     institutions = await api_client.institutions.get(user_uuid=user_uuid)
@@ -46,8 +49,8 @@ async def get_sum_of_depository_balances_latest(
                 utc_starttime=utc_starttime,
                 utc_endtime=utc_endtime,
                 account_types=["depository"],
+            )
         )
-    )
 
     balances_by_institution = await asyncio.gather(*inst_coroutines)
 
@@ -60,10 +63,12 @@ async def get_sum_of_depository_balances_latest(
             balance_dict["institution_id"] = institution_id
 
             balances_flattened.append(balance_dict)
-    
+
     # STEP 4: Here we sort by timestamp so latest balances are on top
-    balances_flattened = sorted(balances_flattened, key=lambda x: x["timestamp"], reverse=True)
-    
+    balances_flattened = sorted(
+        balances_flattened, key=lambda x: x["timestamp"], reverse=True
+    )
+
     # STEP 5: Then we loop through all balances per institution and account and store the latest balance
     latest_balances = {}
     for loan_record in balances_flattened:
@@ -71,7 +76,7 @@ async def get_sum_of_depository_balances_latest(
         if key not in latest_balances:
             # As we go top-down, we only need to store the first balance we found for each institution+account
             latest_balances[key] = loan_record["balance"]
-    
+
     # STEP 6: Finally, we can sum all the balances
     sum_of_balances_latest = sum(latest_balances.values())
 
@@ -97,4 +102,5 @@ if __name__ == "__main__":
             utc_endtime=now,
         )
         print(sum_of_balances_latest)
+
     asyncio.run(main())

--- a/lib/sum_of_minimum_balances/main.py
+++ b/lib/sum_of_minimum_balances/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import asyncio
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Tuple
 
 from pngme.api import AsyncClient
@@ -25,6 +25,10 @@ async def get_sum_of_minimum_balances(
         Sum of minimum balance observed for all depository accounts, in a given time window.
         If balance information was not observed, it returns None.
     """
+    # Make sure the timestamps are of UTC timezone
+    utc_starttime = utc_starttime.astimezone(timezone.utc).replace(tzinfo=None)
+    utc_endtime = utc_endtime.astimezone(timezone.utc).replace(tzinfo=None)
+
     # STEP 1: get a list of all institutions for the user
     institutions = await api_client.institutions.get(user_uuid=user_uuid)
 
@@ -33,7 +37,7 @@ async def get_sum_of_minimum_balances(
     for inst in institutions:
         if "depository" in inst["account_types"]:
             institutions_w_depository.append(inst)
-    
+
     # STEP 2: get a list of all balances for each institution
     inst_coroutines = []
     for inst in institutions_w_depository:
@@ -44,8 +48,8 @@ async def get_sum_of_minimum_balances(
                 utc_starttime=utc_starttime,
                 utc_endtime=utc_endtime,
                 account_types=["depository"],
+            )
         )
-    )
 
     balances_by_institution = await asyncio.gather(*inst_coroutines)
     balances_flattened = []
@@ -58,7 +62,6 @@ async def get_sum_of_minimum_balances(
             balance_dict["institution_id"] = institution_id
 
             balances_flattened.append(balance_dict)
-        
 
     # We only care about the minimum balance observed for each account of each institution
     min_balances = {}
@@ -68,7 +71,7 @@ async def get_sum_of_minimum_balances(
             min_balances[key] = record["balance"]
         else:
             min_balances[key] = min(min_balances[key], record["balance"])
-    
+
     sum_of_account_minimum_balances = sum(min_balances.values())
 
     return sum_of_account_minimum_balances


### PR DESCRIPTION
[PDP-1278](https://pngme-app.atlassian.net/browse/PDP-1278): feature-library: Ensure timestamps passed are of `utc` timezone + minor consistency updates

- All features that deal with timestamps are now sure to be of `UTC` timezone
- Cleanup: Replaced instances of `astype()` with `to_datetime()` to be consistent across all features

NOTE: To work with our current version of the primitive endpoints (mostly `/alerts` and `/transactions`), the timezone information `tzinfo` has been stripped from all date time objects, after making sure that they are of `UTC` timezone (as the `/alerts` and `/transactions` currently expect the timestamp being passed to them, to be in a particular format, which restricts passing timezone info). This is something that could potentially be taken out once the APIs are updated

NOTE 2: Even though it's only the `/transactions` and `/alerts` that are restricting the timezone info from being a part of the timestamp passed, `for the sake of consistency`, even the features which call `/balances` follow the convention of `tzinfo` being stripped out (except for the 2 `average_end_of_day...` features which call the `between()` method of `pandas`, which complains if the `tzinfo` is stripped)