### PR TITLE
[PDP-1279] Updated README files with the `--upgrade` flag for the `pip install` command

### DIFF
--- a/lib/average_end_of_day_depository_balance/README.md
+++ b/lib/average_end_of_day_depository_balance/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/average_end_of_day_loan_balance/README.md
+++ b/lib/average_end_of_day_loan_balance/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/count_betting_and_lottery_events/README.md
+++ b/lib/count_betting_and_lottery_events/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/count_insufficient_funds_events/README.md
+++ b/lib/count_insufficient_funds_events/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/count_loan_declined_events/README.md
+++ b/lib/count_loan_declined_events/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/count_loan_defaulted_events/README.md
+++ b/lib/count_loan_defaulted_events/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/count_loan_repaid_events/README.md
+++ b/lib/count_loan_repaid_events/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/count_loan_repayment_events/README.md
+++ b/lib/count_loan_repayment_events/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/count_missed_payment_events/README.md
+++ b/lib/count_missed_payment_events/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/count_opened_loans/README.md
+++ b/lib/count_opened_loans/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/count_overdraft_events/README.md
+++ b/lib/count_overdraft_events/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/data_recency_minutes/README.md
+++ b/lib/data_recency_minutes/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/debt_to_income_ratio_latest/README.md
+++ b/lib/debt_to_income_ratio_latest/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/net_cash_flow/README.md
+++ b/lib/net_cash_flow/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/standard_deviation_of_week_to_week_sum_of_credits/README.md
+++ b/lib/standard_deviation_of_week_to_week_sum_of_credits/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/sum_of_credits/README.md
+++ b/lib/sum_of_credits/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/sum_of_debits/README.md
+++ b/lib/sum_of_debits/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/sum_of_depository_balances_latest/README.md
+++ b/lib/sum_of_depository_balances_latest/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/sum_of_loan_balances_latest/README.md
+++ b/lib/sum_of_loan_balances_latest/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/sum_of_loan_repayments/README.md
+++ b/lib/sum_of_loan_repayments/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):

--- a/lib/sum_of_minimum_balances/README.md
+++ b/lib/sum_of_minimum_balances/README.md
@@ -10,7 +10,7 @@ source .venv/bin/activate
 2. Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt --upgrade
 ```
 
 3. Set the `PNGME_TOKEN` environment variable using your API token from [admin.pngme.com](https://admin.pngme.com):


### PR DESCRIPTION
- Updated all README files with the `--upgrade` flag for the `pip install` command
- Branched off of [PDP-1278](https://github.com/pngme/pngme-feature-library/tree/PDP-1278), since this is a small change (and the PR might get approved sooner than the [one for PDP-1278](https://github.com/pngme/pngme-feature-library/pull/73))
- Tested locally by having an older version of `pngme-api` already installed and using the `--upgrade` flag, to verify that the version of `pngme-api` pkg mentioned in `requirements.txt` is what gets installed